### PR TITLE
feat: add subtype resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/src/test/java/utils/GeneralConfigModule.java
+++ b/src/test/java/utils/GeneralConfigModule.java
@@ -4,12 +4,18 @@ import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.*;
 import com.github.victools.jsonschema.generator.Module;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class GeneralConfigModule implements Module {
 	@Override
 	public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
 		InsertSchemaPropsProvider descriptionProvider = new InsertSchemaPropsProvider();
 		builder.forTypesInGeneral()
+				.withSubtypeResolver(new ClassGraphSubtypeResolver())
 				.withCustomDefinitionProvider(descriptionProvider)
 				.withTypeAttributeOverride(descriptionProvider);
 	}
@@ -36,6 +42,59 @@ public class GeneralConfigModule implements Module {
 		@Override
 		public void resetAfterSchemaGenerationFinished() {
 			this.mainType = null;
+		}
+	}
+
+	/**
+	 * Simple implementation of a reflection based subtype resolver, considering only subtypes from a certain package.
+	 */
+	private class ClassGraphSubtypeResolver implements SubtypeResolver {
+
+		private final ClassGraph classGraphConfig;
+		private ScanResult scanResult;
+
+		ClassGraphSubtypeResolver() {
+			this.classGraphConfig = new ClassGraph()
+					.enableClassInfo()
+					.enableInterClassDependencies()
+					// in this example, only consider a certain set of potential subtypes
+					.acceptPackages("org.example.model");
+		}
+
+		private ScanResult getScanResult() {
+			if (this.scanResult == null) {
+				this.scanResult = this.classGraphConfig.scan();
+			}
+			return this.scanResult;
+		}
+
+		@Override
+		public void resetAfterSchemaGenerationFinished() {
+			if (this.scanResult != null) {
+				this.scanResult.close();
+				this.scanResult = null;
+			}
+		}
+
+		@Override
+		public List<ResolvedType> findSubtypes(ResolvedType declaredType, SchemaGenerationContext context) {
+			if (declaredType.getErasedType() == Object.class) {
+				return null;
+			}
+			ClassInfoList subtypes;
+			if (declaredType.isInterface()) {
+				subtypes = this.getScanResult().getClassesImplementing(declaredType.getErasedType());
+			} else {
+				subtypes = this.getScanResult().getSubclasses(declaredType.getErasedType());
+			}
+			if (!subtypes.isEmpty()) {
+				TypeContext typeContext = context.getTypeContext();
+				return subtypes.loadClasses(true)
+						.stream()
+						.map(subclass -> typeContext.resolveSubtype(declaredType, subclass))
+						.collect(Collectors.toList());
+			}
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
Add the `ClassGraphSubtypeResolver` from the [SubtypeLookUpExample](https://github.com/victools/jsonschema-generator/blob/main/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/SubtypeLookUpExample.java).

Resulting in the expected schema output:
```yaml
---
$schema: https://json-schema.org/draft/2020-12/schema
type: object
properties:
  pets:
    type: array
    items:
      anyOf:
      - $ref: classpath:///schemas/Cat-schema.yml
      - $ref: classpath:///schemas/Dog-schema.yml
unevaluatedProperties: false

```